### PR TITLE
Add option to handle all settings as roaming

### DIFF
--- a/PortableJsonSettingsProvider/PortableJsonSettingsProvider.cs
+++ b/PortableJsonSettingsProvider/PortableJsonSettingsProvider.cs
@@ -25,6 +25,11 @@ namespace Bluegrams.Application
         /// </summary>
         public static string SettingsDirectory { get; set; } = AppDomain.CurrentDomain.BaseDirectory;
 
+        /// <summary>
+        /// Specifies if all settings should be roaming.
+        /// </summary>
+        public static bool AllRoaming { get; set; } = false;
+
         public override string Name => "PortableJsonSettingsProvider";
 
         /// <summary>
@@ -219,6 +224,8 @@ namespace Bluegrams.Application
         // Iterates through the properties' attributes to determine whether it's set to roam.
         private bool IsRoaming(SettingsProperty prop)
         {
+            if (AllRoaming)
+                return true;
             foreach (DictionaryEntry d in prop.Attributes)
             {
                 Attribute a = (Attribute)d.Value;

--- a/PortableSettingsProvider/PortableSettingsProvider.cs
+++ b/PortableSettingsProvider/PortableSettingsProvider.cs
@@ -24,6 +24,11 @@ namespace Bluegrams.Application
         /// </summary>
         public static string SettingsDirectory { get; set; } = AppDomain.CurrentDomain.BaseDirectory;
 
+        /// <summary>
+        /// Specifies if all settings should be roaming.
+        /// </summary>
+        public static bool AllRoaming { get; set; } = false;
+
         public override string Name => "PortableSettingsProvider";
 
         /// <summary>
@@ -218,6 +223,8 @@ namespace Bluegrams.Application
         // Iterates through the properties' attributes to determine whether it's set to roam.
         private bool IsRoaming(SettingsProperty prop)
         {
+            if (AllRoaming)
+                return true;
             foreach (DictionaryEntry d in prop.Attributes)
             {
                 Attribute a = (Attribute)d.Value;


### PR DESCRIPTION
Adds an option to handle all settings as roaming. This makes the settings portable between machines the "Quick Way" without enabeling each in the UI.
Tests needed.